### PR TITLE
日付範囲の自動設定機能を追加

### DIFF
--- a/manual_tests/manual_test_count_reactions.py
+++ b/manual_tests/manual_test_count_reactions.py
@@ -10,6 +10,7 @@ from qiitareactioncounter.count_reactions import (
     Settings,
     collect_articles,
     get_authenticated_user,
+    get_user_oldest_article_date,
     run_count_reactions,
 )
 from qiitareactioncounter.schemas import ReactionCounts
@@ -164,3 +165,32 @@ def test_collect_articles_sample_size():
 
     # サンプル数の検証
     assert len(user_articles) == user_sample_size
+
+
+def test_get_user_oldest_article_date():
+    """Qiitaの最も古い投稿の日付を取得するテスト
+    ユーザーIDを指定した場合、最も古い投稿の日付が正しく取得できることを確認します。
+
+    実行例:
+        QIITA_USERID=shimajiroxyz uv run pytest manual_tests/manual_test_count_reactions.py -v -s -k test_get_user_oldest_article_date
+    """
+    # 環境変数からQiitaトークンを取得
+    qiita_token = os.getenv("QIITA_TOKEN")
+    if not qiita_token:
+        pytest.skip("環境変数 QIITA_TOKEN が設定されていません")
+
+    # ユーザーIDを環境変数から取得
+    userid = os.getenv("QIITA_USERID", "Qiita")
+
+    # テスト実行
+    settings = Settings()  # type: ignore
+    headers = {"Authorization": f"Bearer {settings.qiita_token}"}
+    oldest_date = get_user_oldest_article_date(headers, userid)
+
+    # 結果の表示
+    print(f"\n取得した最も古い投稿の日付: {oldest_date}")
+
+    # 検証
+    assert oldest_date is not None, "日付が取得できていること"
+    assert isinstance(oldest_date, str), "日付が文字列であること"
+    assert len(oldest_date.split("-")) == 3, "日付がYYYY-MM-DD形式であること"

--- a/manual_tests/manual_test_run_analysis.py
+++ b/manual_tests/manual_test_run_analysis.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from qiitareactioncounter.count_reactions import get_user_oldest_article_date
 from qiitareactioncounter.run_analysis import Settings, run_analysis
 
 
@@ -113,3 +114,76 @@ def test_run_analysis(test_output_dir):
     assert (output_path / f"{user_id}_analysis_result.json").exists(), (
         "認証ユーザーの分析結果が生成されていること"
     )
+
+
+def test_run_analysis_with_auto_date_range(test_output_dir):
+    """日付範囲の自動設定をテストする
+    ユーザーIDを指定した場合、日付範囲が指定されていないと自動的に設定されることを確認します。
+
+    実行例:
+        QIITA_USERID=Qiita uv run pytest manual_tests/manual_test_run_analysis.py -v -k test_run_analysis_with_auto_date_range
+    """
+    # 環境変数からQiitaトークンを取得
+    qiita_token = os.getenv("QIITA_TOKEN")
+    if not qiita_token:
+        pytest.skip("環境変数 QIITA_TOKEN が設定されていません")
+
+    # ユーザーIDを環境変数から取得
+    userid = os.getenv("QIITA_USERID", "Qiita")
+
+    # コマンドライン引数の設定（日付範囲を指定しない）
+    sys.argv = [
+        "script.py",
+        f"--userid={userid}",
+        f"--output_dir={test_output_dir}",
+        "--sample_size=99",
+    ]
+
+    # テスト実行
+    settings = Settings()  # type: ignore
+    run_analysis(settings)
+
+    # 出力ディレクトリの確認
+    output_path = Path(test_output_dir)
+    assert output_path.exists()
+
+    # 全ユーザーの集計結果の確認
+    all_users_csv = output_path / "all_users_reactions.csv"
+    assert all_users_csv.exists()
+    all_users_analysis = output_path / "all_users_analysis_result.json"
+    assert all_users_analysis.exists()
+
+    # 特定ユーザーの集計結果の確認
+    user_csv = output_path / f"{userid}_reactions.csv"
+    assert user_csv.exists()
+    user_analysis = output_path / f"{userid}_analysis_result.json"
+    assert user_analysis.exists()
+
+
+def test_get_oldest_article_date():
+    """Qiitaの最も古い投稿の日付を取得するテスト
+    ユーザーIDを指定した場合、最も古い投稿の日付が正しく取得できることを確認します。
+
+    実行例:
+        QIITA_USERID=Qiita uv run pytest manual_tests/manual_test_run_analysis.py -v -s -k test_get_oldest_article_date
+    """
+    # 環境変数からQiitaトークンを取得
+    qiita_token = os.getenv("QIITA_TOKEN")
+    if not qiita_token:
+        pytest.skip("環境変数 QIITA_TOKEN が設定されていません")
+
+    # ユーザーIDを環境変数から取得
+    userid = os.getenv("QIITA_USERID", "Qiita")
+
+    # テスト実行
+    settings = Settings()  # type: ignore
+    headers = {"Authorization": f"Bearer {settings.qiita_token}"}
+    oldest_date = get_user_oldest_article_date(headers, userid)
+
+    # 結果の表示
+    print(f"\n取得した最も古い投稿の日付: {oldest_date}")
+
+    # 検証
+    assert oldest_date is not None, "日付が取得できていること"
+    assert isinstance(oldest_date, str), "日付が文字列であること"
+    assert len(oldest_date.split("-")) == 3, "日付がYYYY-MM-DD形式であること"

--- a/manual_tests/manual_test_run_analysis.py
+++ b/manual_tests/manual_test_run_analysis.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-from qiitareactioncounter.count_reactions import get_user_oldest_article_date
 from qiitareactioncounter.run_analysis import Settings, run_analysis
 
 
@@ -158,32 +157,3 @@ def test_run_analysis_with_auto_date_range(test_output_dir):
     assert user_csv.exists()
     user_analysis = output_path / f"{userid}_analysis_result.json"
     assert user_analysis.exists()
-
-
-def test_get_oldest_article_date():
-    """Qiitaの最も古い投稿の日付を取得するテスト
-    ユーザーIDを指定した場合、最も古い投稿の日付が正しく取得できることを確認します。
-
-    実行例:
-        QIITA_USERID=Qiita uv run pytest manual_tests/manual_test_run_analysis.py -v -s -k test_get_oldest_article_date
-    """
-    # 環境変数からQiitaトークンを取得
-    qiita_token = os.getenv("QIITA_TOKEN")
-    if not qiita_token:
-        pytest.skip("環境変数 QIITA_TOKEN が設定されていません")
-
-    # ユーザーIDを環境変数から取得
-    userid = os.getenv("QIITA_USERID", "Qiita")
-
-    # テスト実行
-    settings = Settings()  # type: ignore
-    headers = {"Authorization": f"Bearer {settings.qiita_token}"}
-    oldest_date = get_user_oldest_article_date(headers, userid)
-
-    # 結果の表示
-    print(f"\n取得した最も古い投稿の日付: {oldest_date}")
-
-    # 検証
-    assert oldest_date is not None, "日付が取得できていること"
-    assert isinstance(oldest_date, str), "日付が文字列であること"
-    assert len(oldest_date.split("-")) == 3, "日付がYYYY-MM-DD形式であること"


### PR DESCRIPTION
# 日付範囲の自動設定機能を追加

## 内容
- ユーザーの最も古い投稿の日付を取得する機能を追加
- 日付範囲の指定をオプショナルに変更
  - 開始日が指定されていない場合、ユーザーの最も古い投稿の日付を使用
  - 終了日が指定されていない場合、現在の日付を使用
- 手動テストの追加

## 変更理由
- ユーザーが日付範囲を指定しなくても、適切な範囲で分析ができるようにするため
- より使いやすい機能を提供するため
